### PR TITLE
Fix errors related to missing view IDs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,10 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "typescript.tsc.autoDetect": "off",
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#151E82",
+        "titleBar.activeBackground": "#1D29B6",
+        "titleBar.activeForeground": "#F9FAFE"
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
     "name": "vscode-inputstream",
-    "version": "0.5.0",
+    "version": "0.6.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "0.5.0",
+            "name": "vscode-inputstream",
+            "version": "0.6.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "1.1.1",
@@ -1390,7 +1391,6 @@
             "dependencies": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
-                "fsevents": "~2.1.1",
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -6360,10 +6360,8 @@
             "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
             "dev": true,
             "dependencies": {
-                "chokidar": "^3.4.1",
                 "graceful-fs": "^4.1.2",
-                "neo-async": "^2.5.0",
-                "watchpack-chokidar2": "^2.0.0"
+                "neo-async": "^2.5.0"
             },
             "optionalDependencies": {
                 "chokidar": "^3.4.1",
@@ -6494,6 +6492,7 @@
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
             "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
             "dev": true,
+            "hasInstallScript": true,
             "optional": true,
             "os": [
                 "darwin"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-inputstream",
     "displayName": "vscode-inputstream",
     "description": "Streamlined developer publishing",
-    "version": "0.6.1",
+    "version": "0.7.0",
     "publisher": "stackbuild",
     "license": "Apache-2.0",
     "icon": "stackb-full.png",
@@ -28,6 +28,7 @@
     "activationEvents": [
         "onUri",
         "onView:input.stream.inputExplorer",
+        "onView:input.stream.accountExplorer",
         "onCommand:input.stream.login",
         "onCommand:input.stream.deviceLogin",
         "onCommand:input.stream.image.search"
@@ -157,19 +158,19 @@
                     "group": "navigation@0"
                 },
                 {
-                    "command": "input.stream.image.search",
+                    "command": "input.stream.input.create",
                     "when": "view == input.stream.inputExplorer",
                     "group": "navigation@1"
                 },
                 {
-                    "command": "input.stream.input.create",
+                    "command": "input.stream.image.search",
                     "when": "view == input.stream.inputExplorer",
                     "group": "navigation@2"
                 },
                 {
                     "command": "input.stream.deviceLogin",
-                    "when": "view == input.stream.inputExplorer",
-                    "group": "navigation@3"
+                    "when": "view == input.stream.accountExplorer",
+                    "group": "navigation@0"
                 }
             ],
             "view/item/context": [
@@ -215,9 +216,15 @@
             "inputstream-explorer": [
                 {
                     "id": "input.stream.inputExplorer",
-                    "name": "Personal",
+                    "name": "Inputs",
                     "icon": "media/astronaut.svg",
-                    "contextualTitle": "Personal Input List"
+                    "contextualTitle": "Input List"
+                },
+                {
+                    "id": "input.stream.accountExplorer",
+                    "name": "Account",
+                    "icon": "media/astronaut.svg",
+                    "contextualTitle": "Account Details"
                 }
             ]
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,10 +14,10 @@ const features: IExtensionFeature[] = [
 
 export function activate(ctx: vscode.ExtensionContext) {
 	Container.initialize(ctx);
-	
+
 	ctx.subscriptions.push(
 		vscode.commands.registerCommand(
-			CommandName.OpenSetting, 
+			CommandName.OpenSetting,
 			openExtensionSetting));
 
 	Container.telemetry.sendTelemetryEvent(Telemetry.ExtensionActivate);
@@ -39,15 +39,14 @@ function setup(context: vscode.ExtensionContext, feature: IExtensionFeature) {
 		console.log(`skipping feature ${feature.name} (not enabled)`);
 		return;
 	}
-
-	feature.activate(context, config).catch(err => {
+	feature.activate(context, config).then(() => {
+		Container.telemetry.sendTelemetryEvent(Telemetry.FeatureActivate, {
+			'feature': feature.name,
+		});
+	}).catch(err => {
 		vscode.window.showErrorMessage(
 			`could not activate feature "${feature.name}": ${err}`,
 		);
-	});
-
-	Container.telemetry.sendTelemetryEvent(Telemetry.FeatureActivate, {
-		'feature': feature.name,
 	});
 }
 

--- a/src/inputstream/constants.ts
+++ b/src/inputstream/constants.ts
@@ -5,6 +5,7 @@ export const FeatureName = 'input.stream';
 
 export enum ViewName {
     InputExplorer = 'input.stream.inputExplorer',
+    AccountExplorer = 'input.stream.accountExplorer',
 }
 
 export enum Scheme {

--- a/src/inputstream/login/treeview.ts
+++ b/src/inputstream/login/treeview.ts
@@ -2,27 +2,46 @@ import * as vscode from 'vscode';
 import { BuiltInCommands } from '../../constants';
 import { ContextValue, ViewName } from '../constants';
 import { TreeDataProvider } from '../treedataprovider';
+import { User } from '../../proto/build/stack/auth/v1beta1/User';
 
-export class LoginTreeDataProvider extends TreeDataProvider<vscode.TreeItem> {
+export class AccountTreeDataProvider extends TreeDataProvider<vscode.TreeItem> {
+    private user: User | undefined;
+
     constructor() {
-        super(ViewName.InputExplorer);
+        super(ViewName.AccountExplorer);
     }
 
     async getRootItems(): Promise<vscode.TreeItem[]> {
-        const loginUri = vscode.Uri.parse('https://input.stream/settings/extensions/stackbuild.vscode-inputstream/login');
+        if (this.user) {
+            return this.getUserItems(this.user);
+        } else {
+            return this.getLoginItems();
+        }
+    }
 
+    private async getUserItems(user: User): Promise<vscode.TreeItem[]> {
+        const item = new vscode.TreeItem(`@${user.login}`);
+        item.description = `${user.name}`;
+        return [item];
+    }
+
+    private async getLoginItems(): Promise<vscode.TreeItem[]> {
+        const loginUri = vscode.Uri.parse('https://input.stream/settings/extensions/stackbuild.vscode-inputstream/login');
         const item = new vscode.TreeItem('Login');
-        item.contextValue = ContextValue.Login,
-        item.label = 'Login',
-        item.description = 'Click to login',
+        item.contextValue = ContextValue.Login;
+        item.label = 'Login';
+        item.description = 'Click to login';
         item.command = {
             title: 'Login',
             command: BuiltInCommands.Open,
             arguments: [loginUri],
         };
-
         return [item];
     }
 
+    public handleAuthUserChange(user: User) {
+        this.user = user;
+        this._onDidChangeTreeData.fire(undefined);
+    }
 }
 

--- a/src/inputstream/page/filesystem.ts
+++ b/src/inputstream/page/filesystem.ts
@@ -65,9 +65,14 @@ export class PageFileSystemProvider implements vscode.Disposable, vscode.FileSys
             const input = await this.client.getInput({ login, id }, mask);
             return new InputFile(input!);
         } catch (err) {
-            vscode.window.showErrorMessage(`Could not get input content: ${err.message}`);
-            return err;
+            if (err instanceof Error) {
+                vscode.window.showErrorMessage(`Could not get input content: ${err.message}`);
+                throw err;
+            }
         }
+
+        // TODO(pcj): remove this, we are only fooling the compiler
+        return new InputFile({} as Input);
     }
 
     protected async createFile(uri: vscode.Uri, content: Uint8Array): Promise<void> {

--- a/src/inputstream/page/treeview.ts
+++ b/src/inputstream/page/treeview.ts
@@ -10,11 +10,11 @@ import {
     _build_stack_inputstream_v1beta1_Input_Status as InputStatus
 } from '../../proto/build/stack/inputstream/v1beta1/Input';
 import { InputStreamClient } from '../client';
-import { CommandName, ContextValue, getInputURI, Scheme, ThemeIconRss, ViewName } from '../constants';
+import { CommandName, ContextValue, getInputURI, ThemeIconRss, ViewName } from '../constants';
 import { InputStreamClientTreeDataProvider } from '../inputstreamclienttreedataprovider';
 
 /**
- * Renders a view for a user pages.
+ * Renders a view for user pages.
  */
 export class PageTreeView extends InputStreamClientTreeDataProvider<Input> {
     private items: Input[] | undefined;
@@ -107,7 +107,9 @@ export class PageTreeView extends InputStreamClientTreeDataProvider<Input> {
             }
             return inputs;
         } catch (err) {
-            console.log(`Could not list Inputs: ${err.message}`);
+            if (err instanceof Error) {
+                console.log(`Could not list Inputs: ${err.message}`);
+            }
             return undefined;
         }
     }


### PR DESCRIPTION
Instead of dynamically switching the view container when the user logs in, make two permanent tree views: one for account details, the other for the input list.